### PR TITLE
Remove *-redundant-* rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = {
     "declaration-block-no-duplicate-properties": [ true, {
       ignore: ["consecutive-duplicates-with-different-values"],
     } ],
-    "declaration-block-no-redundant-longhand-properties": true,
     "declaration-block-no-shorthand-property-overrides": true,
     "font-family-no-duplicate-names": true,
     "function-calc-no-unspaced-operator": true,
@@ -23,7 +22,6 @@ module.exports = {
     "selector-pseudo-class-no-unknown": true,
     "selector-pseudo-element-no-unknown": true,
     "selector-type-no-unknown": true,
-    "shorthand-property-no-redundant-values": true,
     "string-no-newline": true,
     "unit-no-unknown": true,
   },


### PR DESCRIPTION
Remove `declaration-block-no-redundant-longhand-properties` and `shorthand-property-no-redundant-values` rules.

Closes #14.