### PR TITLE
Add `function-calc-no-invalid` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.0.0
+
+-   Added: `function-calc-no-invalid` rule.
+-   Removed: `stylelint` < 10.1.0 from peer dependencies. stylelint@10.1.0+ is required now.
+
 # 2.2.0
 
 -   Added: `stylelint@10` to peer dependency range.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     "declaration-block-no-shorthand-property-overrides": true,
     "font-family-no-duplicate-names": true,
     "font-family-no-missing-generic-family-keyword": true,
+    "function-calc-no-invalid": true,
     "function-calc-no-unspaced-operator": true,
     "function-linear-gradient-no-nonstandard-direction": true,
     "keyframe-declaration-no-important": true,

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "stylelint": "^10.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^8.3.0 || ^9.0.0 || ^10.0.0"
+    "stylelint": ">=10.1.0"
   },
   "scripts": {
     "dry-release": "npmpub --dry --verbose",


### PR DESCRIPTION
<!---
Please read the following. Pull requests that do not adhere to these guidelines will be closed.

Each pull request must, with the exception of minor documentation fixes, be associated with an open issue. If a corresponding issue does not exist please stop. Instead, create an issue so we can discuss the change first.

If there is an associated open issue, then the next step is to make sure you've read the relevant developer guide:

- Creating a new rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#creating-a-new-rule

- Adding an option to an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#adding-an-option-to-an-existing-rule

- Fixing a bug in an existing rule: https://github.com/stylelint/stylelint/blob/master/docs/developer-guide/rules.md#fixing-a-bug-in-an-existing-rule

Once you've done that, then please continue by answering these two questions:  -->

> Which issue, if any, is this issue related to?

Closes https://github.com/stylelint/stylelint-config-recommended/issues/41

> Is there anything in the PR that needs further explanation?

I removed older versions from peerDependencies, because `function-calc-no-invalid` had issues before 10.1.0.
