### PR TITLE
Replace unit-whitelist with unit-allowed-list in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Since [stylelint 9.7.0](https://github.com/stylelint/stylelint/blob/9.7.0/CHANGE
 
 Simply add a `"rules"` key to your config, then add your overrides and additions there.
 
-For example, to change the `at-rule-no-unknown` rule to use its `ignoreAtRules` option, turn off the `block-no-empty` rule, and add the `unit-whitelist` rule:
+For example, to change the `at-rule-no-unknown` rule to use its `ignoreAtRules` option, turn off the `block-no-empty` rule, and add the `unit-allowed-list` rule:
 
 ```json
 {
@@ -57,7 +57,7 @@ For example, to change the `at-rule-no-unknown` rule to use its `ignoreAtRules` 
       }
     ],
     "block-no-empty": null,
-    "unit-whitelist": ["em", "rem", "s"]
+    "unit-allowed-list": ["em", "rem", "s"]
   }
 }
 ```


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

This PR amends the `README` documentation with the new rule names and links involving `*-allowed-list/*-disallowed-list`, as discussed in stylelint/stylelint#4844 and stylelint/stylelint#4845. In this case, that just involves `unit-whitelist` -> `unit-allowed-list` in one example.

This PR is blocked by:

- [ ] that change being released
- [ ] the stylelint.io website being updated

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #69.

> Is there anything in the PR that needs further explanation?

Nope!