### PR TITLE
Fix `engines.test.js` for multiple potential versions

### DIFF
--- a/__tests__/engines.test.js
+++ b/__tests__/engines.test.js
@@ -15,6 +15,10 @@ describe('engines.node', () => {
 			]).toString(),
 		);
 
-		expect(nodeVersion).toEqual(pkg.engines.node);
+		// `^x.y.z` range can return multiple versions.
+		const nodeVersions = Array.isArray(nodeVersion) ? [...new Set(nodeVersion)] : [nodeVersion];
+
+		expect(nodeVersions).toHaveLength(1);
+		expect(nodeVersions).toContain(pkg.engines.node);
 	});
 });


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Ref <https://github.com/stylelint/stylelint-config-recommended/pull/196#discussion_r1252331613>

> Is there anything in the PR that needs further explanation?

`npm view` can return an array or a single string depending on published versions.

See below:

```console
$ npm view --json stylelint@^15.9.0 engines.node
[
  "^14.13.1 || >=16.0.0",
  "^14.13.1 || >=16.0.0"
]
```

```console
$ npm view --json stylelint@^15.10.0 engines.node
"^14.13.1 || >=16.0.0"
```
