### PR TITLE
Remove `stylelint` from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       development-dependencies:
         dependency-type: 'development'
         exclude-patterns: ['stylelint']
+    ignore:
+      - dependency-name: 'stylelint' # Avoid updating the peer dependency.
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #213

> Is there anything in the PR that needs further explanation?

We want to avoid updating `stylelint` in `peerDependencies`.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore
